### PR TITLE
feat: 쿠폰 발급 기능 추가 및 동시성 테스트 구현

### DIFF
--- a/coupon/src/main/java/org/example/coupon/domain/Coupon.java
+++ b/coupon/src/main/java/org/example/coupon/domain/Coupon.java
@@ -1,0 +1,46 @@
+package org.example.coupon.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Coupon {
+    private Long id;
+    private DiscountType discountType;
+    private Long discountRate;
+    private Long discountPrice;
+    private Long maxQuantity;
+    private Long issuedQuantity;
+    private LocalDateTime validateStartDate;
+    private LocalDateTime validateEndDate;
+    private Long eventId;
+
+    @Builder
+    private Coupon(
+            Long id,
+            DiscountType discountType,
+            Long discountRate,
+            Long discountPrice,
+            Long maxQuantity,
+            Long issuedQuantity,
+            LocalDateTime validateStartDate,
+            LocalDateTime validateEndDate,
+            Long eventId
+    ) {
+        this.id = id;
+        this.discountType = discountType;
+        this.discountRate = discountRate;
+        this.discountPrice = discountPrice;
+        this.maxQuantity = maxQuantity;
+        this.issuedQuantity = issuedQuantity;
+        this.validateStartDate = validateStartDate;
+        this.validateEndDate = validateEndDate;
+        this.eventId = eventId;
+    }
+
+    public void incrementIssuedQuantity() {
+        issuedQuantity++;
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/domain/DiscountType.java
+++ b/coupon/src/main/java/org/example/coupon/domain/DiscountType.java
@@ -1,0 +1,5 @@
+package org.example.coupon.domain;
+
+public enum DiscountType {
+    PERCENT, AMOUNT
+}

--- a/coupon/src/main/java/org/example/coupon/exception/CouponException.java
+++ b/coupon/src/main/java/org/example/coupon/exception/CouponException.java
@@ -1,0 +1,19 @@
+package org.example.coupon.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CouponException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CouponException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public CouponException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/exception/CouponExceptionHandler.java
+++ b/coupon/src/main/java/org/example/coupon/exception/CouponExceptionHandler.java
@@ -1,0 +1,65 @@
+package org.example.coupon.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.coupon.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@RestControllerAdvice
+public class CouponExceptionHandler {
+
+    @ExceptionHandler(value = CouponException.class)
+    public ResponseEntity<String> handleCustomException(CouponException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        String message = e.getErrorCode().getMessage();
+
+        log.error("[CustomException] Status: {}, Message: {}", status, message);
+
+        return new ResponseEntity<>(message, status);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> "[" + fieldError.getField() + "] " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        String errorMessage = String.join(", ", errorMessages);
+
+        log.error("[HandleMethodArgumentNotValidException] Message: {}", errorMessage);
+
+        return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ExceptionHandler(value = NoResourceFoundException.class)
+    public ResponseEntity<String> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error("[NoResourceFoundException] URL = {}, Message = {}", e.getResourcePath(), e.getMessage());
+        return new ResponseEntity<>(COMMON_RESOURCE_NOT_FOUND.getMessage(), NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("[HttpMessageNotReadableException] Message: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(COMMON_JSON_PROCESSING_ERROR.getMessage());
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        log.error("[Exception] Message: {}", e.getMessage(), e);
+        return ResponseEntity.internalServerError().body(COMMON_SYSTEM_ERROR.getMessage());
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/exception/ErrorCode.java
+++ b/coupon/src/main/java/org/example/coupon/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.example.coupon.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    COMMON_SYSTEM_ERROR(INTERNAL_SERVER_ERROR, "서버에 내부 오류가 발생했습니다. 요청을 처리하는 동안 예상치 못한 문제가 발생했습니다."),
+    COMMON_JSON_PROCESSING_ERROR(BAD_REQUEST, "JSON 처리 중 문제가 발생했습니다. 데이터 형식이 잘못되었거나 유효하지 않은 JSON 형식입니다."),
+    COMMON_RESOURCE_NOT_FOUND(NOT_FOUND, "요청한 리소스를 찾을 수 없습니다. 요청한 URL에 해당하는 리소스가 없거나 삭제되었을 수 있습니다."),
+    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, null),
+    INVALID_REQUEST(BAD_REQUEST, "데이터 요청 형식이 올바르지 않습니다."),
+
+    COUPON_NOT_FOUND(NOT_FOUND, "쿠폰을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponJpaRepository.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package org.example.coupon.infrastructure;
+
+import org.example.coupon.infrastructure.entity.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
+}

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
@@ -1,0 +1,26 @@
+package org.example.coupon.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.infrastructure.entity.CouponEntity;
+import org.example.coupon.service.port.CouponRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<Coupon> findById(Long id) {
+        return couponJpaRepository.findById(id).map(CouponEntity::toModel);
+    }
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(CouponEntity.fromModel(coupon)).toModel();
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
@@ -20,7 +20,7 @@ public class CouponRepositoryImpl implements CouponRepository {
     }
 
     @Override
-    public Coupon save(Coupon coupon) {
-        return couponJpaRepository.save(CouponEntity.fromModel(coupon)).toModel();
+    public void save(Coupon coupon) {
+        couponJpaRepository.save(CouponEntity.fromModel(coupon)).toModel();
     }
 }

--- a/coupon/src/main/java/org/example/coupon/infrastructure/entity/CouponEntity.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/entity/CouponEntity.java
@@ -1,0 +1,63 @@
+package org.example.coupon.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.domain.DiscountType;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "coupons")
+public class CouponEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Enumerated(STRING)
+    private DiscountType discountType;
+    private Long discountRate;
+    private Long discountPrice;
+    private Long maxQuantity;
+    private Long issuedQuantity;
+    private LocalDateTime validateStartDate;
+    private LocalDateTime validateEndDate;
+
+    private Long eventId;
+
+    public static CouponEntity fromModel(Coupon coupon) {
+        CouponEntity couponEntity = new CouponEntity();
+        couponEntity.id = coupon.getId();
+        couponEntity.discountType = coupon.getDiscountType();
+        couponEntity.discountRate = coupon.getDiscountRate();
+        couponEntity.discountPrice = coupon.getDiscountPrice();
+        couponEntity.maxQuantity = coupon.getMaxQuantity();
+        couponEntity.issuedQuantity = coupon.getIssuedQuantity();
+        couponEntity.validateStartDate = coupon.getValidateStartDate();
+        couponEntity.validateEndDate = coupon.getValidateEndDate();
+        couponEntity.eventId = coupon.getEventId();
+        return couponEntity;
+    }
+
+    public Coupon toModel() {
+        return Coupon.builder()
+                .id(id)
+                .discountType(discountType)
+                .discountRate(discountRate)
+                .discountPrice(discountPrice)
+                .maxQuantity(maxQuantity)
+                .issuedQuantity(issuedQuantity)
+                .validateStartDate(validateStartDate)
+                .validateEndDate(validateEndDate)
+                .eventId(eventId)
+                .build();
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/service/CouponService.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponService.java
@@ -1,0 +1,28 @@
+package org.example.coupon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.exception.CouponException;
+import org.example.coupon.service.port.CouponRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.coupon.exception.ErrorCode.COUPON_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new CouponException(COUPON_NOT_FOUND));
+    }
+
+    @Transactional
+    public void saveCoupon(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
+++ b/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
@@ -8,5 +8,5 @@ public interface CouponRepository {
 
     Optional<Coupon> findById(Long id);
 
-    Coupon save(Coupon coupon);
+    void save(Coupon coupon);
 }

--- a/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
+++ b/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
@@ -1,0 +1,12 @@
+package org.example.coupon.service.port;
+
+import org.example.coupon.domain.Coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+
+    Optional<Coupon> findById(Long id);
+
+    Coupon save(Coupon coupon);
+}

--- a/issue-coupon/build.gradle
+++ b/issue-coupon/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(':coupon')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/issue-coupon/src/main/java/org/example/issuecoupon/IssueCouponApplication.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/IssueCouponApplication.java
@@ -3,7 +3,7 @@ package org.example.issuecoupon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"org.example.coupon", "org.example.issuecoupon"})
 public class IssueCouponApplication {
 
     public static void main(String[] args) {

--- a/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
@@ -1,0 +1,22 @@
+package org.example.issuecoupon.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.issuecoupon.domain.SaveCouponIssueRequest;
+import org.example.issuecoupon.service.CouponIssueService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/coupons")
+@RequiredArgsConstructor
+public class CouponIssueController {
+
+    private final CouponIssueService couponIssueService;
+
+    @PostMapping("/issues")
+    public ResponseEntity<Void> issueCoupon(@RequestBody @Valid SaveCouponIssueRequest saveCouponIssueRequest) {
+        couponIssueService.issueCoupon(saveCouponIssueRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
@@ -1,0 +1,30 @@
+package org.example.issuecoupon.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import static org.example.issuecoupon.domain.CouponStatus.ACTIVE;
+
+@Getter
+public class CouponIssue {
+    private final Long id;
+    private final CouponStatus couponStatus;
+    private final Long couponId;
+    private final Long userId;
+
+    @Builder
+    private CouponIssue(Long id, CouponStatus couponStatus, Long couponId, Long userId) {
+        this.id = id;
+        this.couponStatus = couponStatus;
+        this.couponId = couponId;
+        this.userId = userId;
+    }
+
+    public static CouponIssue of(Long couponId, Long userId) {
+        return CouponIssue.builder()
+                .couponStatus(ACTIVE)
+                .couponId(couponId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponStatus.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponStatus.java
@@ -1,0 +1,5 @@
+package org.example.issuecoupon.domain;
+
+public enum CouponStatus {
+    ACTIVE, USED, EXPIRED;
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/SaveCouponIssueRequest.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/SaveCouponIssueRequest.java
@@ -1,0 +1,8 @@
+package org.example.issuecoupon.domain;
+
+public record SaveCouponIssueRequest(
+        Long userId,
+        Long eventId,
+        Long couponId
+) {
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/exception/ErrorCode.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package org.example.issuecoupon.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+    COMMON_SYSTEM_ERROR(INTERNAL_SERVER_ERROR, "서버에 내부 오류가 발생했습니다. 요청을 처리하는 동안 예상치 못한 문제가 발생했습니다."),
+    COMMON_JSON_PROCESSING_ERROR(BAD_REQUEST, "JSON 처리 중 문제가 발생했습니다. 데이터 형식이 잘못되었거나 유효하지 않은 JSON 형식입니다."),
+    COMMON_RESOURCE_NOT_FOUND(NOT_FOUND, "요청한 리소스를 찾을 수 없습니다. 요청한 URL에 해당하는 리소스가 없거나 삭제되었을 수 있습니다."),
+    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, null),
+    INVALID_REQUEST(BAD_REQUEST, "데이터 요청 형식이 올바르지 않습니다."),
+
+    COUPON_ISSUE_QUANTITY_EXCEEDED(BAD_REQUEST, "쿠폰 발급 수량이 초과되었습니다."),
+    COUPON_ALREADY_ISSUED_BY_USER(BAD_REQUEST, "사용자가 이미 이 쿠폰을 발급받았습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/exception/IssueCouponException.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/exception/IssueCouponException.java
@@ -1,0 +1,19 @@
+package org.example.issuecoupon.exception;
+
+import lombok.Getter;
+
+@Getter
+public class IssueCouponException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public IssueCouponException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public IssueCouponException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/exception/IssueCouponExceptionHandler.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/exception/IssueCouponExceptionHandler.java
@@ -1,0 +1,65 @@
+package org.example.issuecoupon.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.issuecoupon.exception.ErrorCode.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@RestControllerAdvice
+public class IssueCouponExceptionHandler {
+
+    @ExceptionHandler(value = IssueCouponException.class)
+    public ResponseEntity<String> handleCustomException(IssueCouponException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        String message = e.getErrorCode().getMessage();
+
+        log.error("[CustomException] Status: {}, Message: {}", status, message);
+
+        return new ResponseEntity<>(message, status);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> "[" + fieldError.getField() + "] " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        String errorMessage = String.join(", ", errorMessages);
+
+        log.error("[HandleMethodArgumentNotValidException] Message: {}", errorMessage);
+
+        return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ExceptionHandler(value = NoResourceFoundException.class)
+    public ResponseEntity<String> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error("[NoResourceFoundException] URL = {}, Message = {}", e.getResourcePath(), e.getMessage());
+        return new ResponseEntity<>(COMMON_RESOURCE_NOT_FOUND.getMessage(), NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("[HttpMessageNotReadableException] Message: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(COMMON_JSON_PROCESSING_ERROR.getMessage());
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        log.error("[Exception] Message: {}", e.getMessage(), e);
+        return ResponseEntity.internalServerError().body(COMMON_SYSTEM_ERROR.getMessage());
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueJpaRepository.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueJpaRepository.java
@@ -1,0 +1,9 @@
+package org.example.issuecoupon.infrastructure;
+
+import org.example.issuecoupon.infrastructure.entity.CouponIssueEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponIssueJpaRepository extends JpaRepository<CouponIssueEntity, Long> {
+
+    boolean existsByCouponIdAndUserId(Long couponId, Long userId);
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueRepositoryImpl.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.example.issuecoupon.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.issuecoupon.domain.CouponIssue;
+import org.example.issuecoupon.infrastructure.entity.CouponIssueEntity;
+import org.example.issuecoupon.service.port.CouponIssueRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponIssueRepositoryImpl implements CouponIssueRepository {
+
+    private final CouponIssueJpaRepository couponIssueJpaRepository;
+
+    @Override
+    public CouponIssue save(CouponIssue couponIssue) {
+        return couponIssueJpaRepository.save(CouponIssueEntity.fromModel(couponIssue)).toModel();
+    }
+
+    @Override
+    public boolean existsByCouponIdAndUserId(Long couponId, Long userId) {
+        return couponIssueJpaRepository.existsByCouponIdAndUserId(couponId, userId);
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/entity/CouponIssueEntity.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/entity/CouponIssueEntity.java
@@ -1,0 +1,44 @@
+package org.example.issuecoupon.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.issuecoupon.domain.CouponIssue;
+import org.example.issuecoupon.domain.CouponStatus;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "coupon_issues")
+@NoArgsConstructor(access = PROTECTED)
+public class CouponIssueEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Enumerated(STRING)
+    private CouponStatus status;
+    private Long couponId;
+    private Long userId;
+
+    public static CouponIssueEntity fromModel(CouponIssue couponIssue) {
+        CouponIssueEntity couponIssueEntity = new CouponIssueEntity();
+        couponIssueEntity.id = couponIssue.getId();
+        couponIssueEntity.status = couponIssue.getCouponStatus();
+        couponIssueEntity.couponId = couponIssue.getCouponId();
+        couponIssueEntity.userId = couponIssue.getUserId();
+        return couponIssueEntity;
+    }
+
+    public CouponIssue toModel() {
+        return CouponIssue.builder()
+                .id(id)
+                .couponStatus(status)
+                .couponId(couponId)
+                .build();
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/service/CouponIssueService.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/service/CouponIssueService.java
@@ -1,0 +1,76 @@
+package org.example.issuecoupon.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.service.CouponService;
+import org.example.issuecoupon.domain.CouponIssue;
+import org.example.issuecoupon.domain.SaveCouponIssueRequest;
+import org.example.issuecoupon.exception.IssueCouponException;
+import org.example.issuecoupon.service.port.CouponIssueRepository;
+import org.springframework.stereotype.Service;
+
+import static org.example.issuecoupon.exception.ErrorCode.COUPON_ALREADY_ISSUED_BY_USER;
+import static org.example.issuecoupon.exception.ErrorCode.COUPON_ISSUE_QUANTITY_EXCEEDED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponIssueService {
+
+    private final CouponService couponService;
+    private final CouponIssueRepository couponIssueRepository;
+
+    @Transactional
+    public void issueCoupon(SaveCouponIssueRequest saveCouponIssueRequest) {
+        Long couponId = saveCouponIssueRequest.couponId();
+        Long userId = saveCouponIssueRequest.userId();
+        log.info("Issuing Coupon. " +
+                "Coupon ID: [{}], User ID: [{}]", couponId, userId);
+
+        if (!isTotalIssueQuantityAvailable(couponId)) {
+            throw new IssueCouponException(COUPON_ISSUE_QUANTITY_EXCEEDED);
+        }
+        if (isUserAlreadyIssuedCoupon(couponId, userId)) {
+            throw new IssueCouponException(COUPON_ALREADY_ISSUED_BY_USER);
+        }
+
+        saveCouponIssue(couponId, userId);
+        incrementIssuedQuantity(couponId);
+        log.info("Coupon Issued Successfully. " +
+                "Coupon ID: [{}], User ID: [{}]", couponId, userId);
+    }
+
+    private Coupon getCoupon(Long couponId) {
+        return couponService.getCoupon(couponId);
+    }
+
+    private boolean isTotalIssueQuantityAvailable(Long couponId) {
+        Coupon coupon = getCoupon(couponId);
+        Long maxQuantity = coupon.getMaxQuantity();
+        Long issuedQuantity = coupon.getIssuedQuantity();
+        log.info("Checking Total Issue Quantity. " +
+                "Issued Count: [{}], Max Quantity: [{}]", issuedQuantity, maxQuantity);
+        return issuedQuantity < maxQuantity;
+    }
+
+    private boolean isUserAlreadyIssuedCoupon(Long couponId, Long userId) {
+        log.info("Verifying User Coupon Issue Status. " +
+                "Coupon ID: [{}], User ID: [{}]", couponId, userId);
+        return couponIssueRepository.existsByCouponIdAndUserId(couponId, userId);
+    }
+
+    private void saveCouponIssue(Long couponId, Long userId) {
+        log.info("Saving Coupon Issue Request. " +
+                "Coupon ID: [{}], User ID: [{}]", couponId, userId);
+        CouponIssue couponIssue = CouponIssue.of(couponId, userId);
+        couponIssueRepository.save(couponIssue);
+    }
+
+    private void incrementIssuedQuantity(Long couponId) {
+        Coupon coupon = getCoupon(couponId);
+        coupon.incrementIssuedQuantity();
+        couponService.saveCoupon(coupon);
+    }
+}

--- a/issue-coupon/src/main/java/org/example/issuecoupon/service/port/CouponIssueRepository.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/service/port/CouponIssueRepository.java
@@ -1,0 +1,10 @@
+package org.example.issuecoupon.service.port;
+
+import org.example.issuecoupon.domain.CouponIssue;
+
+public interface CouponIssueRepository {
+
+    CouponIssue save(CouponIssue couponIssue);
+
+    boolean existsByCouponIdAndUserId(Long couponId, Long userId);
+}

--- a/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
+++ b/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
@@ -1,0 +1,51 @@
+package org.example.issuecoupon.service;
+
+import org.example.issuecoupon.domain.SaveCouponIssueRequest;
+import org.example.issuecoupon.exception.IssueCouponException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest
+public class CouponIssueServiceTest {
+
+    @Autowired
+    private CouponIssueService couponIssueService;
+
+    @Test
+    void issueCouponConcurrencyTest() throws InterruptedException {
+        int threadCount = 100;
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i;
+            executorService.submit(() -> {
+                try {
+                    SaveCouponIssueRequest saveCouponIssueRequest = new SaveCouponIssueRequest(userId, 1L, 1L);
+                    couponIssueService.issueCoupon(saveCouponIssueRequest);
+                    successCount.incrementAndGet();
+                } catch (IssueCouponException e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        System.out.println("Issue Coupon Success Count: " + successCount.get());
+        System.out.println("Issue Coupon Fail Count: " + failCount.get());
+    }
+}


### PR DESCRIPTION
### 개요
`CouponIssueService`의 쿠폰 발급 로직을 구현하고, 쿠폰 발급 시 발생하는 동시성 문제를 확인하기 위해 동시성 테스트를 추가.

### 주요 변경 사항
- `CouponIssueService`: 쿠폰 발급 시 재고량 확인 및 중복 발급 검증 로직 추가
- `CouponIssueRepository`: 발급 정보 저장 및 중복 발급 검증 기능 추가
- `CouponIssueServiceTest`: 동시성 테스트를 통해 발급 시 동시성 문제 확인

### 동시성 문제점 및 발생 상황
<img width="1624" alt="스크린샷 2024-11-10 23 01 51" src="https://github.com/user-attachments/assets/97a2667c-37a1-4a9a-aa3b-d465a2732061">
동시성 제어 없이 테스트를 수행한 결과 다음과 같은 문제가 발생.

- 재고 초과 발급 문제: 쿠폰의 최대 발급 수량을 초과하여 발급되는 현상 발생.
- 발생 원인 (Lost Update): 여러 스레드가 동시에 재고를 확인하고 발급 절차를 수행하면서 재고 수량이 정확히 반영되지 않음.

### 성능 저하 문제
매번 데이터베이스에서 실시간 재고 정보를 확인하고 있어, 많은 동시 요청이 들어오는 경우 성능 저하가 발생할 수 있음.

### 참고 사항
동시성 문제를 해결하고 성능을 개선하기 위해, 향후 Redis를 활용한 Transaction 및 Command 적용을 통해 동시성 제어 및 캐싱을 고려.