### PR TITLE
feat: Redis 도입 및 Redis Transaction 적용을 통한 쿠폰 발급 기능 개선

### DIFF
--- a/coupon/src/main/java/org/example/coupon/domain/Coupon.java
+++ b/coupon/src/main/java/org/example/coupon/domain/Coupon.java
@@ -7,28 +7,21 @@ import java.time.LocalDateTime;
 
 @Getter
 public class Coupon {
-    private Long id;
-    private DiscountType discountType;
-    private Long discountRate;
-    private Long discountPrice;
-    private Long maxQuantity;
-    private Long issuedQuantity;
-    private LocalDateTime validateStartDate;
-    private LocalDateTime validateEndDate;
-    private Long eventId;
+
+    private final Long id;
+    private final DiscountType discountType;
+    private final Long discountRate;
+    private final Long discountPrice;
+    private final Long maxQuantity;
+    private final Long issuedQuantity;
+    private final LocalDateTime validateStartDate;
+    private final LocalDateTime validateEndDate;
+    private final Long eventId;
 
     @Builder
-    private Coupon(
-            Long id,
-            DiscountType discountType,
-            Long discountRate,
-            Long discountPrice,
-            Long maxQuantity,
-            Long issuedQuantity,
-            LocalDateTime validateStartDate,
-            LocalDateTime validateEndDate,
-            Long eventId
-    ) {
+    private Coupon(Long id, DiscountType discountType, Long discountRate, Long discountPrice,
+                   Long maxQuantity, Long issuedQuantity, LocalDateTime validateStartDate,
+                   LocalDateTime validateEndDate, Long eventId) {
         this.id = id;
         this.discountType = discountType;
         this.discountRate = discountRate;
@@ -38,9 +31,5 @@ public class Coupon {
         this.validateStartDate = validateStartDate;
         this.validateEndDate = validateEndDate;
         this.eventId = eventId;
-    }
-
-    public void incrementIssuedQuantity() {
-        issuedQuantity++;
     }
 }

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
@@ -18,9 +18,4 @@ public class CouponRepositoryImpl implements CouponRepository {
     public Optional<Coupon> findById(Long id) {
         return couponJpaRepository.findById(id).map(CouponEntity::toModel);
     }
-
-    @Override
-    public void save(Coupon coupon) {
-        couponJpaRepository.save(CouponEntity.fromModel(coupon)).toModel();
-    }
 }

--- a/coupon/src/main/java/org/example/coupon/service/CouponService.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponService.java
@@ -20,9 +20,4 @@ public class CouponService {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new CouponException(COUPON_NOT_FOUND));
     }
-
-    @Transactional
-    public void saveCoupon(Coupon coupon) {
-        couponRepository.save(coupon);
-    }
 }

--- a/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
+++ b/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
@@ -7,6 +7,4 @@ import java.util.Optional;
 public interface CouponRepository {
 
     Optional<Coupon> findById(Long id);
-
-    void save(Coupon coupon);
 }

--- a/issue-coupon/build.gradle
+++ b/issue-coupon/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation project(':coupon')
+    implementation project(':redis')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/issue-coupon/src/main/java/org/example/issuecoupon/IssueCouponApplication.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/IssueCouponApplication.java
@@ -3,7 +3,7 @@ package org.example.issuecoupon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = {"org.example.coupon", "org.example.issuecoupon"})
+@SpringBootApplication(scanBasePackages = {"org.example.coupon", "org.example.redis", "org.example.issuecoupon"})
 public class IssueCouponApplication {
 
     public static void main(String[] args) {

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
@@ -7,6 +7,7 @@ import static org.example.issuecoupon.domain.CouponStatus.ACTIVE;
 
 @Getter
 public class CouponIssue {
+
     private final Long id;
     private final CouponStatus couponStatus;
     private final Long couponId;

--- a/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueJpaRepository.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueJpaRepository.java
@@ -4,6 +4,4 @@ import org.example.issuecoupon.infrastructure.entity.CouponIssueEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponIssueJpaRepository extends JpaRepository<CouponIssueEntity, Long> {
-
-    boolean existsByCouponIdAndUserId(Long couponId, Long userId);
 }

--- a/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueRepositoryImpl.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/infrastructure/CouponIssueRepositoryImpl.java
@@ -13,12 +13,7 @@ public class CouponIssueRepositoryImpl implements CouponIssueRepository {
     private final CouponIssueJpaRepository couponIssueJpaRepository;
 
     @Override
-    public CouponIssue save(CouponIssue couponIssue) {
-        return couponIssueJpaRepository.save(CouponIssueEntity.fromModel(couponIssue)).toModel();
-    }
-
-    @Override
-    public boolean existsByCouponIdAndUserId(Long couponId, Long userId) {
-        return couponIssueJpaRepository.existsByCouponIdAndUserId(couponId, userId);
+    public void save(CouponIssue couponIssue) {
+        couponIssueJpaRepository.save(CouponIssueEntity.fromModel(couponIssue));
     }
 }

--- a/issue-coupon/src/main/java/org/example/issuecoupon/service/port/CouponIssueRepository.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/service/port/CouponIssueRepository.java
@@ -4,7 +4,5 @@ import org.example.issuecoupon.domain.CouponIssue;
 
 public interface CouponIssueRepository {
 
-    CouponIssue save(CouponIssue couponIssue);
-
-    boolean existsByCouponIdAndUserId(Long couponId, Long userId);
+    void save(CouponIssue couponIssue);
 }

--- a/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
+++ b/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
@@ -1,7 +1,7 @@
 package org.example.issuecoupon.service;
 
 import org.example.issuecoupon.domain.SaveCouponIssueRequest;
-import org.example.issuecoupon.exception.IssueCouponException;
+import org.example.redis.exception.RedisException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,7 +34,7 @@ public class CouponIssueServiceTest {
                     SaveCouponIssueRequest saveCouponIssueRequest = new SaveCouponIssueRequest(userId, 1L, 1L);
                     couponIssueService.issueCoupon(saveCouponIssueRequest);
                     successCount.incrementAndGet();
-                } catch (IssueCouponException e) {
+                } catch (RedisException e) {
                     failCount.incrementAndGet();
                 } finally {
                     latch.countDown();

--- a/redis/build.gradle
+++ b/redis/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.jetbrains:annotations:24.0.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/redis/src/main/java/org/example/redis/config/RedisConfig.java
+++ b/redis/src/main/java/org/example/redis/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package org.example.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/redis/src/main/java/org/example/redis/domain/CouponCache.java
+++ b/redis/src/main/java/org/example/redis/domain/CouponCache.java
@@ -1,0 +1,27 @@
+package org.example.redis.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CouponCache {
+
+    private final Long id;
+    private final Long maxQuantity;
+    private final Long eventId;
+
+    @Builder
+    private CouponCache(Long id, Long maxQuantity, Long eventId) {
+        this.id = id;
+        this.maxQuantity = maxQuantity;
+        this.eventId = eventId;
+    }
+
+    public static CouponCache of(Long id, Long maxQuantity, Long eventId) {
+        return CouponCache.builder()
+                .id(id)
+                .maxQuantity(maxQuantity)
+                .eventId(eventId)
+                .build();
+    }
+}

--- a/redis/src/main/java/org/example/redis/exception/RedisErrorCode.java
+++ b/redis/src/main/java/org/example/redis/exception/RedisErrorCode.java
@@ -1,0 +1,23 @@
+package org.example.redis.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RequiredArgsConstructor
+@Getter
+public enum RedisErrorCode {
+    COMMON_SYSTEM_ERROR(INTERNAL_SERVER_ERROR, "서버에 내부 오류가 발생했습니다. 요청을 처리하는 동안 예상치 못한 문제가 발생했습니다."),
+    COMMON_JSON_PROCESSING_ERROR(BAD_REQUEST, "JSON 처리 중 문제가 발생했습니다. 데이터 형식이 잘못되었거나 유효하지 않은 JSON 형식입니다."),
+    COMMON_RESOURCE_NOT_FOUND(NOT_FOUND, "요청한 리소스를 찾을 수 없습니다. 요청한 URL에 해당하는 리소스가 없거나 삭제되었을 수 있습니다."),
+    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, null),
+    INVALID_REQUEST(BAD_REQUEST, "데이터 요청 형식이 올바르지 않습니다."),
+
+    COUPON_ISSUE_QUANTITY_EXCEEDED(BAD_REQUEST, "쿠폰 발급 수량이 초과되었습니다."),
+    COUPON_ALREADY_ISSUED_BY_USER(BAD_REQUEST, "사용자가 이미 이 쿠폰을 발급받았습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/redis/src/main/java/org/example/redis/exception/RedisException.java
+++ b/redis/src/main/java/org/example/redis/exception/RedisException.java
@@ -1,0 +1,19 @@
+package org.example.redis.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RedisException extends RuntimeException {
+
+    private final RedisErrorCode redisErrorCode;
+
+    public RedisException(String message, RedisErrorCode redisErrorCode) {
+        super(message);
+        this.redisErrorCode = redisErrorCode;
+    }
+
+    public RedisException(RedisErrorCode redisErrorCode) {
+        super(redisErrorCode.getMessage());
+        this.redisErrorCode = redisErrorCode;
+    }
+}

--- a/redis/src/main/java/org/example/redis/exception/RedisExceptionHandler.java
+++ b/redis/src/main/java/org/example/redis/exception/RedisExceptionHandler.java
@@ -1,0 +1,65 @@
+package org.example.redis.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.redis.exception.RedisErrorCode.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@RestControllerAdvice
+public class RedisExceptionHandler {
+
+    @ExceptionHandler(value = RedisException.class)
+    public ResponseEntity<String> handleCustomException(RedisException e) {
+        HttpStatus status = e.getRedisErrorCode().getHttpStatus();
+        String message = e.getRedisErrorCode().getMessage();
+
+        log.error("[CustomException] Status: {}, Message: {}", status, message);
+
+        return new ResponseEntity<>(message, status);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> "[" + fieldError.getField() + "] " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        String errorMessage = String.join(", ", errorMessages);
+
+        log.error("[HandleMethodArgumentNotValidException] Message: {}", errorMessage);
+
+        return ResponseEntity.badRequest().body(errorMessage);
+    }
+
+    @ExceptionHandler(value = NoResourceFoundException.class)
+    public ResponseEntity<String> handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error("[NoResourceFoundException] URL = {}, Message = {}", e.getResourcePath(), e.getMessage());
+        return new ResponseEntity<>(COMMON_RESOURCE_NOT_FOUND.getMessage(), NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("[HttpMessageNotReadableException] Message: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(COMMON_JSON_PROCESSING_ERROR.getMessage());
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        log.error("[Exception] Message: {}", e.getMessage(), e);
+        return ResponseEntity.internalServerError().body(COMMON_SYSTEM_ERROR.getMessage());
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CommonCacheStoreImpl.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CommonCacheStoreImpl.java
@@ -1,0 +1,39 @@
+package org.example.redis.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.redis.exception.RedisException;
+import org.example.redis.service.port.CommonCacheStore;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.redis.exception.RedisErrorCode.COMMON_SYSTEM_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommonCacheStoreImpl implements CommonCacheStore {
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * Redis에서 세션 콜백을 실행하는 메서드.
+     * 트랜잭션 작업 또는 여러 명령어를 한 세션에서 처리할 때 사용.
+     *
+     * @param sessionCallback 실행할 세션 콜백
+     * @param <T> 세션 콜백 실행의 결과 타입
+     * @throws RedisException 세션 콜백 실행 중 예외 발생 시 공통 예외로 처리
+     */
+    @Override
+    public <T> void execute(SessionCallback<T> sessionCallback) {
+        log.info("Executing Redis Session Callback");
+        try {
+            redisTemplate.execute(sessionCallback);
+            log.info("Redis Session Callback Executed Successfully.");
+        } catch (Exception e) {
+            log.error("Redis Session Callback Exception", e);
+            throw new RedisException("Failed to Execute Redis Session Callback", COMMON_SYSTEM_ERROR);
+        }
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponCacheStoreImpl.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponCacheStoreImpl.java
@@ -1,0 +1,26 @@
+package org.example.redis.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.redis.domain.CouponCache;
+import org.example.redis.infrastructure.vo.CouponRedisVO;
+import org.example.redis.service.port.CouponCacheStore;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class CouponCacheStoreImpl implements CouponCacheStore {
+
+    private final CouponRedisCache couponRedisCache;
+
+    @Override
+    public Optional<CouponCache> getCoupon(String key) {
+        return couponRedisCache.getCoupon(key).map(CouponRedisVO::toModel);
+    }
+
+    @Override
+    public void saveCoupon(String key, CouponCache couponCache) {
+        couponRedisCache.setCoupon(key, CouponRedisVO.fromModel(couponCache));
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponIssueCacheStoreImpl.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponIssueCacheStoreImpl.java
@@ -1,0 +1,22 @@
+package org.example.redis.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.redis.service.port.CouponIssueCacheStore;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponIssueCacheStoreImpl implements CouponIssueCacheStore {
+
+    private final CouponIssueRedisCache couponIssueRedisCache;
+
+    @Override
+    public Long getIssuedCouponUserCount(String issueRequestKey) {
+        return couponIssueRedisCache.getIssuedCouponUserCount(issueRequestKey);
+    }
+
+    @Override
+    public Long addIssuedCouponUser(String issueRequestKey, String userId) {
+        return couponIssueRedisCache.addIssuedCouponUser(issueRequestKey, userId);
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponIssueRedisCache.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponIssueRedisCache.java
@@ -1,0 +1,55 @@
+package org.example.redis.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.redis.exception.RedisException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+import static org.example.redis.exception.RedisErrorCode.COMMON_SYSTEM_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponIssueRedisCache {
+
+    private final static Long NO_USERS_ISSUED = 0L;
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * Redis의 SCARD 명령어를 사용하여 특정 쿠폰에 대해 발급된 사용자 수를 확인.
+     *
+     * @param key 쿠폰이 발급된 사용자 데이터를 저장하는 Redis 집합의 키.
+     * @return 해당 쿠폰을 발급받은 사용자 수. 존재하지 않을 경우 0을 반환.
+     * @throws RedisException Redis에서 사용자 수 조회 중 예외가 발생할 경우 공통 예외로 처리.
+     */
+    public Long getIssuedCouponUserCount(String key) {
+        try {
+            Long count = redisTemplate.opsForSet().size(key);
+            return Objects.requireNonNullElse(count, NO_USERS_ISSUED);
+        } catch (Exception e) {
+            log.error("Failed to Get Issued Coupon User Count for Key: [{}]", key, e);
+            throw new RedisException("Failed to Get Issued Coupon User Count", COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    /**
+     * Redis의 SADD 명령어를 사용하여 특정 쿠폰에 대해 사용자를 추가.
+     *
+     * @param key 쿠폰 발급 사용자 데이터를 저장하는 Redis 집합의 키.
+     * @param value 발급받은 사용자를 나타내는 식별자.
+     * @return 사용자가 쿠폰 집합에 성공적으로 추가되면 true, 그렇지 않다면 false.
+     * @throws RedisException Redis에서 사용자 추가 중 예외가 발생할 경우 공통 예외로 처리.
+     */
+    public Long addIssuedCouponUser(String key, String value) {
+        try {
+            Long result = redisTemplate.opsForSet().add(key, value);
+            return Objects.requireNonNullElse(result, NO_USERS_ISSUED);
+        } catch (Exception e) {
+            log.error("Failed to Add Issued Coupon User for Key: [{}], Value: [{}]", key, value, e);
+            throw new RedisException("Failed to Add Issued Coupon User", COMMON_SYSTEM_ERROR);
+        }
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponRedisCache.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponRedisCache.java
@@ -1,0 +1,56 @@
+package org.example.redis.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.redis.exception.RedisException;
+import org.example.redis.infrastructure.vo.CouponRedisVO;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static org.example.redis.exception.RedisErrorCode.COMMON_SYSTEM_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponRedisCache {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<CouponRedisVO> getCoupon(String key) {
+        log.info("Find Redis Key = [{}]", key);
+        String serializedValue = redisTemplate.opsForValue().get(key);
+        try {
+            return Optional.of(objectMapper.readValue(serializedValue, CouponRedisVO.class));
+        } catch (IllegalArgumentException | InvalidFormatException e) {
+            log.error("Failed to Deserialize Coupon for key [{}]", key, e);
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Redis Get Exception for key [{}]", key, e);
+            throw new RedisException("Redis get() Error", COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    /**
+     * 쿠폰 객체를 Redis에 저장하는 메서드.
+     * 주어진 쿠폰 객체를 CouponRedisEntity로 변환하여 직렬화 후 Redis에 저장.
+     *
+     * @param key Redis에 저장될 쿠폰 데이터의 키.
+     * @param couponRedisVO Redis에 저장할 쿠폰 객체.
+     * @throws RedisException 직렬화 또는 Redis 저장 중 예외 발생 시 공통 예외로 처리.
+     */
+    public void setCoupon(String key, CouponRedisVO couponRedisVO) {
+        log.info("Save Redis Key = [{}], Value = [{}]", key, couponRedisVO);
+        try {
+            String serializedValue = objectMapper.writeValueAsString(couponRedisVO);
+            redisTemplate.opsForValue().set(key, serializedValue);
+        } catch (Exception e) {
+            log.error("Redis Set Exception", e);
+            throw new RedisException("Redis set() Error", COMMON_SYSTEM_ERROR);
+        }
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/vo/CouponRedisVO.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/vo/CouponRedisVO.java
@@ -1,0 +1,36 @@
+package org.example.redis.infrastructure.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.redis.domain.CouponCache;
+
+@Getter
+public class CouponRedisVO {
+
+    private final Long id;
+    private final Long maxQuantity;
+    private final Long eventId;
+
+    @Builder
+    private CouponRedisVO(Long id, Long maxQuantity, Long eventId) {
+        this.id = id;
+        this.maxQuantity = maxQuantity;
+        this.eventId = eventId;
+    }
+
+    public static CouponRedisVO fromModel(CouponCache couponCache) {
+        return CouponRedisVO.builder()
+                .id(couponCache.getId())
+                .maxQuantity(couponCache.getMaxQuantity())
+                .eventId(couponCache.getEventId())
+                .build();
+    }
+
+    public CouponCache toModel() {
+        return CouponCache.builder()
+                .id(id)
+                .maxQuantity(maxQuantity)
+                .eventId(eventId)
+                .build();
+    }
+}

--- a/redis/src/main/java/org/example/redis/service/CouponIssueRedisService.java
+++ b/redis/src/main/java/org/example/redis/service/CouponIssueRedisService.java
@@ -1,0 +1,67 @@
+package org.example.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.redis.domain.CouponCache;
+import org.example.redis.exception.RedisException;
+import org.example.redis.service.port.CommonCacheStore;
+import org.example.redis.service.port.CouponIssueCacheStore;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.stereotype.Component;
+
+import static org.example.redis.exception.RedisErrorCode.COUPON_ALREADY_ISSUED_BY_USER;
+import static org.example.redis.exception.RedisErrorCode.COUPON_ISSUE_QUANTITY_EXCEEDED;
+import static org.example.redis.utils.RedisKeyUtils.getCouponIssueRequestKey;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponIssueRedisService {
+
+    private final static Long ADD_SUCCESS = 1L;
+
+    private final CouponIssueCacheStore couponIssueCacheStore;
+    private final CommonCacheStore commonCacheStore;
+
+    public void checkCouponIssueQuantityAndDuplicate(CouponCache couponCache, String userId) {
+        commonCacheStore.execute(new SessionCallback<>() {
+            @Override
+            public <K, V> Object execute(@NotNull RedisOperations<K, V> operations) throws DataAccessException {
+                operations.multi();
+
+                Long couponId = couponCache.getId();
+                Long maxQuantity = couponCache.getMaxQuantity();
+                log.info("Checking Total Issued Coupon Quantity and Duplicate Issuance." +
+                        "Coupon ID: [{}], User ID: [{}]", couponId, userId);
+
+                String couponIssueRequestKey = getCouponIssueRequestKey(couponId);
+                if (!isTotalIssueQuantityAvailable(couponIssueRequestKey, maxQuantity)) {
+                    throw new RedisException(COUPON_ISSUE_QUANTITY_EXCEEDED);
+                }
+                if (isUserAlreadyIssuedCoupon(couponIssueRequestKey, userId)) {
+                    throw new RedisException(COUPON_ALREADY_ISSUED_BY_USER);
+                }
+
+                return operations.exec();
+            }
+        });
+    }
+
+    private boolean isTotalIssueQuantityAvailable(String couponIssueRequestKey, Long maxQuantity) {
+        Long issuedCount = couponIssueCacheStore.getIssuedCouponUserCount(couponIssueRequestKey);
+        log.info("Checking Total Issued Coupon Quantity. " +
+                        "Issued Request Key: [{}], Issued Count: [{}], Max Quantity: [{}]",
+                couponIssueRequestKey, issuedCount, maxQuantity);
+        return issuedCount < maxQuantity;
+    }
+
+    public boolean isUserAlreadyIssuedCoupon(String issueRequestKey, String userId) {
+        Long result = couponIssueCacheStore.addIssuedCouponUser(issueRequestKey, userId);
+        log.debug("Verifying User Coupon Issue Status. " +
+                "User ID: [{}], Issue Request Key: [{}], Result: [{}]", userId, issueRequestKey, result);
+        return result >= ADD_SUCCESS;
+    }
+}

--- a/redis/src/main/java/org/example/redis/service/CouponRedisService.java
+++ b/redis/src/main/java/org/example/redis/service/CouponRedisService.java
@@ -1,0 +1,34 @@
+package org.example.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.redis.domain.CouponCache;
+import org.example.redis.service.port.CouponCacheStore;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static org.example.redis.utils.RedisKeyUtils.getCouponKey;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponRedisService {
+
+    private final CouponCacheStore couponCacheStore;
+
+    public Optional<CouponCache> getCoupon(Long couponId) {
+        String couponKey = getCouponKey(couponId);
+        log.info("Getting Coupon. " +
+                "Coupon ID: [{}], Generated Key: [{}]", couponId, couponKey);
+        return couponCacheStore.getCoupon(couponKey);
+    }
+
+    public void saveCoupon(CouponCache couponCache) {
+        Long couponId = couponCache.getId();
+        String couponKey = getCouponKey(couponId);
+        log.info("Saving Coupon " +
+                "Coupon ID: [{}], Key: [{}]", couponId, couponKey);
+        couponCacheStore.saveCoupon(couponKey, couponCache);
+    }
+}

--- a/redis/src/main/java/org/example/redis/service/port/CommonCacheStore.java
+++ b/redis/src/main/java/org/example/redis/service/port/CommonCacheStore.java
@@ -1,0 +1,8 @@
+package org.example.redis.service.port;
+
+import org.springframework.data.redis.core.SessionCallback;
+
+public interface CommonCacheStore {
+
+    <T> void execute(SessionCallback<T> sessionCallback);
+}

--- a/redis/src/main/java/org/example/redis/service/port/CouponCacheStore.java
+++ b/redis/src/main/java/org/example/redis/service/port/CouponCacheStore.java
@@ -1,0 +1,12 @@
+package org.example.redis.service.port;
+
+import org.example.redis.domain.CouponCache;
+
+import java.util.Optional;
+
+public interface CouponCacheStore {
+
+    Optional<CouponCache> getCoupon(String key);
+
+    void saveCoupon(String key, CouponCache couponCache);
+}

--- a/redis/src/main/java/org/example/redis/service/port/CouponIssueCacheStore.java
+++ b/redis/src/main/java/org/example/redis/service/port/CouponIssueCacheStore.java
@@ -1,0 +1,8 @@
+package org.example.redis.service.port;
+
+public interface CouponIssueCacheStore {
+
+    Long getIssuedCouponUserCount(String issueRequestKey);
+
+    Long addIssuedCouponUser(String key, String userId);
+}

--- a/redis/src/main/java/org/example/redis/utils/RedisKeyUtils.java
+++ b/redis/src/main/java/org/example/redis/utils/RedisKeyUtils.java
@@ -1,0 +1,18 @@
+package org.example.redis.utils;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RedisKeyUtils {
+
+    private static final String COUPON_PREFIX = "coupon:couponId=%s";
+    private static final String COUPON_ISSUE_REQUEST_PREFIX = "coupon:issue:request:couponId=%s:users";
+
+    public static String getCouponKey(Long couponId) {
+        return COUPON_PREFIX.formatted(couponId);
+    }
+
+    public static String getCouponIssueRequestKey(Long couponId) {
+        return COUPON_ISSUE_REQUEST_PREFIX.formatted(couponId);
+    }
+}


### PR DESCRIPTION
### 개요
- 쿠폰 발급 시스템에 Redis 캐싱을 통합해서 성능을 최적화
- Redis 트랜잭션 처리를 통해 동시성 해결 시도

### 주요 변경 사항

- **Redis 통합**: Lettuce 클라이언트를 사용해 Redis와 연결하고, Redis 템플릿을 설정
- **쿠폰 발급 로직 개선**: Redis를 사용해 쿠폰 발급 수량과 중복 발급 여부를 체크하는 로직을 추가
- **트랜잭션 처리 추가**: Redis 트랜잭션을 통해 쿠폰 초과 발급 문제를 해결
- **테스트 추가**: Redis 캐싱과 트랜잭션 처리에 대한 단위 테스트와 동시성 테스트를 추가

### Redis에서 Get 연산과 트랜잭션 적용 시 발생하는 문제

<img width="898" alt="스크린샷 2024-11-11 11 04 40" src="https://github.com/user-attachments/assets/74c7daa0-4ca4-45b9-b1f4-42485a36f362">

- `SCARD` 명령어로 쿠폰을 발급받은 사용자 수를 가져올 때 `null` 값이 반환되는 문제가 발생
- Redis는 `MULTI`로 트랜잭션을 시작하고, `EXEC`로 트랜잭션을 실행함. 큐에 쌓인 명령어들이 순차적으로 실행
-  트랜잭션 내에서 `GET`을 호출하면 트랜잭션이 끝날 때까지 값이 유효하지 않아서 `null`이 반환
- 트랜잭션 외부에서 값을 조회할 수 있지만, 이 방법은 동시성 문제를 해결할 수 없음
- 원자적 연산을 제공하는 Lua 스크립트를 적용할 예정