### PR TITLE
feat: Write-Back 전략을 활용한 캐시와 DB 동기화 구현

### DIFF
--- a/coupon/build.gradle
+++ b/coupon/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(':redis')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/coupon/src/main/java/org/example/coupon/CouponApplication.java
+++ b/coupon/src/main/java/org/example/coupon/CouponApplication.java
@@ -3,7 +3,7 @@ package org.example.coupon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"org.example.coupon", "org.example.redis"})
 public class CouponApplication {
 
     public static void main(String[] args) {

--- a/coupon/src/main/java/org/example/coupon/config/ScheduleConfig.java
+++ b/coupon/src/main/java/org/example/coupon/config/ScheduleConfig.java
@@ -1,0 +1,7 @@
+package org.example.coupon.config;
+
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponJpaRepository.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponJpaRepository.java
@@ -2,6 +2,20 @@ package org.example.coupon.infrastructure;
 
 import org.example.coupon.infrastructure.entity.CouponEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
+
+    @Modifying
+    @Query("""
+           UPDATE CouponEntity c
+           SET c.issuedQuantity = :issuedQuantity
+           WHERE c.id = :id
+           """)
+    void updateIssuedQuantity(
+            @Param("id") Long id,
+            @Param("issuedQuantity") Long issuedQuantity
+    );
 }

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.example.coupon.infrastructure.entity.CouponEntity;
 import org.example.coupon.service.port.CouponRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,5 +18,17 @@ public class CouponRepositoryImpl implements CouponRepository {
     @Override
     public Optional<Coupon> findById(Long id) {
         return couponJpaRepository.findById(id).map(CouponEntity::toModel);
+    }
+
+    @Override
+    public void updateIssuedQuantity(Long id, Long issuedCount) {
+        couponJpaRepository.updateIssuedQuantity(id, issuedCount);
+    }
+
+    @Override
+    public List<Coupon> findAll() {
+        return couponJpaRepository.findAll().stream()
+                .map(CouponEntity::toModel)
+                .toList();
     }
 }

--- a/coupon/src/main/java/org/example/coupon/service/CouponService.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponService.java
@@ -7,6 +7,8 @@ import org.example.coupon.service.port.CouponRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.example.coupon.exception.ErrorCode.COUPON_NOT_FOUND;
 
 @Service
@@ -19,5 +21,9 @@ public class CouponService {
     public Coupon getCoupon(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new CouponException(COUPON_NOT_FOUND));
+    }
+
+    public List<Coupon> getAllCoupons() {
+        return couponRepository.findAll();
     }
 }

--- a/coupon/src/main/java/org/example/coupon/service/CouponSyncScheduler.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponSyncScheduler.java
@@ -1,0 +1,45 @@
+package org.example.coupon.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.service.port.CouponRepository;
+import org.example.redis.service.CouponIssueRedisService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponSyncScheduler {
+
+    private static final Long NO_ISSUED_COUNT = 0L;
+
+    private final CouponService couponService;
+    private final CouponIssueRedisService couponIssueRedisService;
+    private final CouponRepository couponRepository;
+
+    @Scheduled(
+            initialDelay = 60000,
+            fixedDelay = 60000
+    )
+    @Transactional
+    public void issuedQuantityUpdate() {
+        log.info("Starting Issued Quantity Update for Coupons.");
+        List<Coupon> coupons = couponService.getAllCoupons();
+        for (Coupon coupon : coupons) {
+            Long couponId = coupon.getId();
+            Long issuedCount = couponIssueRedisService.getIssuedCouponCount(couponId);
+            if (!Objects.equals(issuedCount, NO_ISSUED_COUNT)) {
+                couponRepository.updateIssuedQuantity(couponId, issuedCount);
+                log.info("Updated Issued Quantity. " +
+                        "Coupon ID: [{}] Issued Count: [{}]", couponId, issuedCount);
+            }
+        }
+        log.info("Completed Issued Quantity Update for All Coupons.");
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
+++ b/coupon/src/main/java/org/example/coupon/service/port/CouponRepository.java
@@ -2,9 +2,14 @@ package org.example.coupon.service.port;
 
 import org.example.coupon.domain.Coupon;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CouponRepository {
 
     Optional<Coupon> findById(Long id);
+
+    void updateIssuedQuantity(Long id, Long issuedCount);
+
+    List<Coupon> findAll();
 }

--- a/coupon/src/test/java/org/example/coupon/service/CouponSyncSchedulerTest.java
+++ b/coupon/src/test/java/org/example/coupon/service/CouponSyncSchedulerTest.java
@@ -1,0 +1,116 @@
+package org.example.coupon.service;
+
+import org.example.coupon.domain.Coupon;
+import org.example.coupon.service.port.CouponRepository;
+import org.example.redis.service.CouponIssueRedisService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.example.coupon.domain.DiscountType.AMOUNT;
+import static org.example.coupon.domain.DiscountType.PERCENT;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@EnableScheduling
+public class CouponSyncSchedulerTest {
+
+    @InjectMocks
+    private CouponSyncScheduler couponSyncScheduler;
+
+    @Mock
+    private CouponService couponService;
+
+    @Mock
+    private CouponIssueRedisService couponIssueRedisService;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Test
+    @DisplayName("[SUCCESS] 쿠폰 발급 수량 업데이트가 성공적으로 처리된다")
+    void issuedQuantityUpdate() {
+        // Given
+        Coupon coupon1 = Coupon.builder()
+                .id(1L)
+                .discountType(PERCENT)
+                .discountRate(10L)
+                .maxQuantity(100L)
+                .issuedQuantity(50L)
+                .validateStartDate(LocalDateTime.now())
+                .validateEndDate(LocalDateTime.now().plusDays(10))
+                .eventId(1L)
+                .build();
+        Coupon coupon2 = Coupon.builder()
+                .id(2L)
+                .discountType(AMOUNT)
+                .discountPrice(1000L)
+                .maxQuantity(200L)
+                .issuedQuantity(150L)
+                .validateStartDate(LocalDateTime.now())
+                .validateEndDate(LocalDateTime.now().plusDays(10))
+                .eventId(2L)
+                .build();
+        List<Coupon> coupons = Arrays.asList(coupon1, coupon2);
+
+        when(couponService.getAllCoupons()).thenReturn(coupons);
+        when(couponIssueRedisService.getIssuedCouponCount(coupon1.getId())).thenReturn(50L);
+        when(couponIssueRedisService.getIssuedCouponCount(coupon2.getId())).thenReturn(150L);
+
+        // When
+        couponSyncScheduler.issuedQuantityUpdate();
+
+        // Then
+        verify(couponRepository, times(1)).updateIssuedQuantity(coupon1.getId(), 50L);
+        verify(couponRepository, times(1)).updateIssuedQuantity(coupon2.getId(), 150L);
+        verify(couponService, times(1)).getAllCoupons();
+        verify(couponIssueRedisService, times(2)).getIssuedCouponCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 발급 수량이 없는 경우 업데이트가 발생하지 않는다")
+    void noUpdateWhenZeroIssued() {
+        // Given
+        Coupon coupon1 = Coupon.builder()
+                .id(1L)
+                .discountType(PERCENT)
+                .discountRate(10L)
+                .maxQuantity(100L)
+                .issuedQuantity(50L)
+                .validateStartDate(LocalDateTime.now())
+                .validateEndDate(LocalDateTime.now().plusDays(10))
+                .eventId(1L)
+                .build();
+        Coupon coupon2 = Coupon.builder()
+                .id(2L)
+                .discountType(AMOUNT)
+                .discountPrice(1000L)
+                .maxQuantity(200L)
+                .issuedQuantity(150L)
+                .validateStartDate(LocalDateTime.now())
+                .validateEndDate(LocalDateTime.now().plusDays(10))
+                .eventId(2L)
+                .build();
+        List<Coupon> coupons = Arrays.asList(coupon1, coupon2);
+
+        when(couponService.getAllCoupons()).thenReturn(coupons);
+        when(couponIssueRedisService.getIssuedCouponCount(coupon1.getId())).thenReturn(0L);
+        when(couponIssueRedisService.getIssuedCouponCount(coupon2.getId())).thenReturn(0L);
+
+        // When
+        couponSyncScheduler.issuedQuantityUpdate();
+
+        // Then
+        verify(couponRepository, never()).updateIssuedQuantity(anyLong(), anyLong());
+        verify(couponService, times(1)).getAllCoupons();
+        verify(couponIssueRedisService, times(2)).getIssuedCouponCount(anyLong());
+    }
+}

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponIssueCacheStoreImpl.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponIssueCacheStoreImpl.java
@@ -14,4 +14,9 @@ public class CouponIssueCacheStoreImpl implements CouponIssueCacheStore {
     public Long checkCouponIssueAvailability(String couponIssueRequestKey, String maxQuantity, String userId) {
         return couponIssueRedisCache.checkCouponIssueAvailability(couponIssueRequestKey, maxQuantity, userId);
     }
+
+    @Override
+    public Long getIssuedCouponUserCount(String issueRequestKey) {
+        return couponIssueRedisCache.getIssuedCouponUserCount(issueRequestKey);
+    }
 }

--- a/redis/src/main/java/org/example/redis/infrastructure/CouponIssueRedisCache.java
+++ b/redis/src/main/java/org/example/redis/infrastructure/CouponIssueRedisCache.java
@@ -1,16 +1,21 @@
 package org.example.redis.infrastructure;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 import static java.util.Collections.singletonList;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CouponIssueRedisCache {
 
+    private final static Long NO_USERS_ISSUED = 0L;
     private final StringRedisTemplate redisTemplate;
 
     /**
@@ -42,5 +47,16 @@ public class CouponIssueRedisCache {
                 singletonList(couponIssueRequestKey),
                 maxQuantity, userId
         );
+    }
+
+    /**
+     * Redis의 SCARD 명령어를 사용하여 특정 쿠폰에 대해 발급된 사용자 수를 확인.
+     *
+     * @param key 쿠폰이 발급된 사용자 데이터를 저장하는 Redis 집합의 키.
+     * @return 해당 쿠폰을 발급받은 사용자 수. 존재하지 않을 경우 0을 반환.
+     */
+    public Long getIssuedCouponUserCount(String key) {
+        Long count = redisTemplate.opsForSet().size(key);
+        return Objects.requireNonNullElse(count, NO_USERS_ISSUED);
     }
 }

--- a/redis/src/main/java/org/example/redis/service/CouponIssueRedisService.java
+++ b/redis/src/main/java/org/example/redis/service/CouponIssueRedisService.java
@@ -34,4 +34,9 @@ public class CouponIssueRedisService {
             default -> throw new RedisException(COMMON_SYSTEM_ERROR);
         }
     }
+
+    public Long getIssuedCouponCount(Long couponId) {
+        String issuedCountKey = getCouponIssueRequestKey(couponId);
+        return couponIssueCacheStore.getIssuedCouponUserCount(issuedCountKey);
+    }
 }

--- a/redis/src/main/java/org/example/redis/service/port/CouponIssueCacheStore.java
+++ b/redis/src/main/java/org/example/redis/service/port/CouponIssueCacheStore.java
@@ -3,4 +3,6 @@ package org.example.redis.service.port;
 public interface CouponIssueCacheStore {
 
     Long checkCouponIssueAvailability(String couponIssueRequestKey, String maxQuantity, String userId);
+
+    Long getIssuedCouponUserCount(String issuedCountKey);
 }


### PR DESCRIPTION
### 개요
쿠폰 관리 시스템에 Redis 캐시 전략을 적용하여 쿠폰 발급 수량을 관리하고, 해당 수량을 주기적으로 업데이트하는 기능을 추가

### 주요 변경 사항
- **스케줄링 설정**: `ScheduleConfig` 클래스에 `@EnableScheduling`을 활성화시켜, 주기적으로 쿠폰 발급 수량을 업데이트
- **레포지토리 업데이트**
   - `CouponJpaRepository`에 `updateIssuedQuantity` 메서드를 추가하여 발급 수량을 업데이트
   - `CouponRepositoryImpl`에 `findAll` 및 `updateIssuedQuantity` 메서드를 추가
- **Redis 캐싱**
  - Redis 캐시를 사용하여 쿠폰 발급 수량을 조회하고 업데이트하는 기능을 추가 
  - Write-Back 전략을 적용하여 발급 수량을 Redis에서 주기적으로 DB에 반영
-  **단위 테스트 추가**: 발급 수량이 정상적으로 업데이트되는지, 발급 수량이 0일 경우 업데이트가 발생하지 않는지 등을 검증

### 참고 사항
- 캐시와 데이터베이스 간의 동기화 전략으로 Write-Back 방식을 적용하여 Redis에 저장된 발급 수량을 주기적으로 데이터베이스에 반영
- 데이터베이스의 업데이트 빈도를 줄이면서 성능을 향상