### PR TITLE
feat: RestTemplate을 이용한 Redis Service에서 쿠폰 발급 개수 조회 기능 추가

### DIFF
--- a/coupon/src/main/java/org/example/coupon/config/RestTemplateConfig.java
+++ b/coupon/src/main/java/org/example/coupon/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package org.example.coupon.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/config/ScheduleConfig.java
+++ b/coupon/src/main/java/org/example/coupon/config/ScheduleConfig.java
@@ -1,7 +1,9 @@
 package org.example.coupon.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@Configuration
 @EnableScheduling
 public class ScheduleConfig {
 }

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponApiClientImpl.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponApiClientImpl.java
@@ -1,0 +1,17 @@
+package org.example.coupon.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.example.coupon.service.port.CouponApiClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponApiClientImpl implements CouponApiClient {
+
+    private final CouponRestTemplateClient issueCouponRestTemplateClient;
+
+    @Override
+    public Long requestGetIssuedCouponCount(String getIssuedCouponCountUrl) {
+        return issueCouponRestTemplateClient.get(getIssuedCouponCountUrl, Long.class).get();
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/infrastructure/CouponRestTemplateClient.java
+++ b/coupon/src/main/java/org/example/coupon/infrastructure/CouponRestTemplateClient.java
@@ -1,0 +1,32 @@
+package org.example.coupon.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.coupon.exception.CouponException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.example.coupon.exception.ErrorCode.COMMON_SYSTEM_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponRestTemplateClient {
+
+    private final RestTemplate restTemplate;
+
+    public <T> Optional<T> get(String url, Class<T> type) {
+        try {
+            return Optional.ofNullable(restTemplate.getForObject(url, type));
+        } catch (HttpClientErrorException e) {
+            log.error("RestTemplate Get Exception Message = [{}]", e.getMessage());
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("RestTemplate Get Exception", e);
+            throw new CouponException(COMMON_SYSTEM_ERROR);
+        }
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/service/CouponApiService.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponApiService.java
@@ -1,0 +1,23 @@
+package org.example.coupon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.coupon.service.port.CouponApiClient;
+import org.springframework.stereotype.Component;
+
+import static org.example.coupon.utils.RequestUrlUtils.*;
+
+@Component
+@RequiredArgsConstructor
+public class CouponApiService {
+
+    private final CouponApiClient couponApiClient;
+
+    public Long requestGetIssuedCouponCount(Long couponId) {
+        String getIssuedCouponCountUrl = buildUriWithPathVariable(
+                REDIS_SERVICE_URL,
+                GET_ISSUED_COUPON_COUNT_ENDPOINT,
+                couponId
+        );
+        return couponApiClient.requestGetIssuedCouponCount(getIssuedCouponCountUrl);
+    }
+}

--- a/coupon/src/main/java/org/example/coupon/service/CouponSyncScheduler.java
+++ b/coupon/src/main/java/org/example/coupon/service/CouponSyncScheduler.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.coupon.domain.Coupon;
 import org.example.coupon.service.port.CouponRepository;
-import org.example.redis.service.CouponIssueRedisService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +19,7 @@ public class CouponSyncScheduler {
     private static final Long NO_ISSUED_COUNT = 0L;
 
     private final CouponService couponService;
-    private final CouponIssueRedisService couponIssueRedisService;
+    private final CouponApiService couponApiService;
     private final CouponRepository couponRepository;
 
     @Scheduled(
@@ -33,7 +32,7 @@ public class CouponSyncScheduler {
         List<Coupon> coupons = couponService.getAllCoupons();
         for (Coupon coupon : coupons) {
             Long couponId = coupon.getId();
-            Long issuedCount = couponIssueRedisService.getIssuedCouponCount(couponId);
+            Long issuedCount = couponApiService.requestGetIssuedCouponCount(couponId);
             if (!Objects.equals(issuedCount, NO_ISSUED_COUNT)) {
                 couponRepository.updateIssuedQuantity(couponId, issuedCount);
                 log.info("Updated Issued Quantity. " +

--- a/coupon/src/main/java/org/example/coupon/service/port/CouponApiClient.java
+++ b/coupon/src/main/java/org/example/coupon/service/port/CouponApiClient.java
@@ -1,0 +1,6 @@
+package org.example.coupon.service.port;
+
+public interface CouponApiClient {
+
+    Long requestGetIssuedCouponCount(String getIssuedCouponCountUrl);
+}

--- a/coupon/src/main/java/org/example/coupon/utils/RequestUrlUtils.java
+++ b/coupon/src/main/java/org/example/coupon/utils/RequestUrlUtils.java
@@ -1,0 +1,22 @@
+package org.example.coupon.utils;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@UtilityClass
+public class RequestUrlUtils {
+
+    public static final String REDIS_SERVICE_URL = "http://localhost:8084";
+    public static final String GET_ISSUED_COUPON_COUNT_ENDPOINT = "/redis/coupon-issues/{couponId}/count";;
+
+    public static String buildUriWithPathVariable(String baseUrl, String endpoint, Long pathVariable) {
+        return UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path(endpoint)
+                .buildAndExpand(pathVariable)
+                .encode(UTF_8)
+                .toUriString();
+    }
+}

--- a/coupon/src/test/java/org/example/coupon/service/CouponSyncSchedulerTest.java
+++ b/coupon/src/test/java/org/example/coupon/service/CouponSyncSchedulerTest.java
@@ -2,7 +2,6 @@ package org.example.coupon.service;
 
 import org.example.coupon.domain.Coupon;
 import org.example.coupon.service.port.CouponRepository;
-import org.example.redis.service.CouponIssueRedisService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +29,7 @@ public class CouponSyncSchedulerTest {
     private CouponService couponService;
 
     @Mock
-    private CouponIssueRedisService couponIssueRedisService;
+    private CouponApiService couponApiService;
 
     @Mock
     private CouponRepository couponRepository;
@@ -62,8 +61,8 @@ public class CouponSyncSchedulerTest {
         List<Coupon> coupons = Arrays.asList(coupon1, coupon2);
 
         when(couponService.getAllCoupons()).thenReturn(coupons);
-        when(couponIssueRedisService.getIssuedCouponCount(coupon1.getId())).thenReturn(50L);
-        when(couponIssueRedisService.getIssuedCouponCount(coupon2.getId())).thenReturn(150L);
+        when(couponApiService.requestGetIssuedCouponCount(coupon1.getId())).thenReturn(50L);
+        when(couponApiService.requestGetIssuedCouponCount(coupon2.getId())).thenReturn(150L);
 
         // When
         couponSyncScheduler.issuedQuantityUpdate();
@@ -72,7 +71,7 @@ public class CouponSyncSchedulerTest {
         verify(couponRepository, times(1)).updateIssuedQuantity(coupon1.getId(), 50L);
         verify(couponRepository, times(1)).updateIssuedQuantity(coupon2.getId(), 150L);
         verify(couponService, times(1)).getAllCoupons();
-        verify(couponIssueRedisService, times(2)).getIssuedCouponCount(anyLong());
+        verify(couponApiService, times(2)).requestGetIssuedCouponCount(anyLong());
     }
 
     @Test
@@ -102,8 +101,8 @@ public class CouponSyncSchedulerTest {
         List<Coupon> coupons = Arrays.asList(coupon1, coupon2);
 
         when(couponService.getAllCoupons()).thenReturn(coupons);
-        when(couponIssueRedisService.getIssuedCouponCount(coupon1.getId())).thenReturn(0L);
-        when(couponIssueRedisService.getIssuedCouponCount(coupon2.getId())).thenReturn(0L);
+        when(couponApiService.requestGetIssuedCouponCount(coupon1.getId())).thenReturn(0L);
+        when(couponApiService.requestGetIssuedCouponCount(coupon2.getId())).thenReturn(0L);
 
         // When
         couponSyncScheduler.issuedQuantityUpdate();
@@ -111,6 +110,6 @@ public class CouponSyncSchedulerTest {
         // Then
         verify(couponRepository, never()).updateIssuedQuantity(anyLong(), anyLong());
         verify(couponService, times(1)).getAllCoupons();
-        verify(couponIssueRedisService, times(2)).getIssuedCouponCount(anyLong());
+        verify(couponApiService, times(2)).requestGetIssuedCouponCount(anyLong());
     }
 }

--- a/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
@@ -8,13 +8,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/coupons")
+@RequestMapping("/coupon-issues")
 @RequiredArgsConstructor
 public class CouponIssueController {
 
     private final CouponIssueService couponIssueService;
 
-    @PostMapping("/issues")
+    @PostMapping
     public ResponseEntity<Void> issueCoupon(@RequestBody @Valid SaveCouponIssueRequest saveCouponIssueRequest) {
         couponIssueService.issueCoupon(saveCouponIssueRequest);
         return ResponseEntity.ok().build();


### PR DESCRIPTION
### **개요**
- `RestTemplate`을 사용하여 쿠폰 발급 개수를 조회하는 기능을 구현
- 이를 통해 외부 서비스의 데이터를 비동기로 가져와 쿠폰 발급 현황을 동기화할 수 있도록 개선

**주요 변경사항**:
- **`RestTemplateConfig` 클래스 추가**
   - `RestTemplate` 빈을 생성하여 외부 API 호출을 위한 설정을 추가
- **API 클라이언트 인터페이스 및 구현 클래스 추가**
   - `CouponApiClient` 인터페이스와 `CouponApiClientImpl` 구현체를 추가하여 쿠폰 발급 개수를 조회하는 API 클라이언트를 정의
- **스케줄러 로직 업데이트**
   - 기존 Redis를 통한 조회 방식을 `CouponApiService`로 변경하여 API를 통한 쿠폰 발급 개수 조회로 로직을 수정
- **테스트 코드 수정**
   - `CouponSyncSchedulerTest`에서 변경된 API 서비스 로직을 반영하여 테스트 코드를 수정

