### PR TITLE
feat: Gateway 서버의 토큰 인증 필터 적용 및 쿠폰 발급 시 사용자 ID 처리 기능 추가

### DIFF
--- a/gateway-server/src/main/java/org/example/gatewayserver/authentication/TokenAuthenticationFilter.java
+++ b/gateway-server/src/main/java/org/example/gatewayserver/authentication/TokenAuthenticationFilter.java
@@ -27,16 +27,14 @@ public class TokenAuthenticationFilter implements GlobalFilter {
     public static final String BEARER_PREFIX = "Bearer ";
     public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
     public static final String USER_ID_HEADER = "X-User-Id";
-
-    private static final String REGISTER_PATH = "/users/sign-up";
-    private static final String LOGIN_PATH = "/users/login";
+    private static final String COUPON_ISSUES_PATH = "/coupon-issues";
 
     private final TokenAuthenticationService tokenAuthenticationService;
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String path = exchange.getRequest().getURI().getPath();
-        if (List.of(REGISTER_PATH, LOGIN_PATH).contains(path)) {
+        if (!path.equals(COUPON_ISSUES_PATH)) {
             return chain.filter(exchange);
         }
 

--- a/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/controller/CouponIssueController.java
@@ -1,11 +1,14 @@
 package org.example.issuecoupon.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.issuecoupon.domain.dto.SaveCouponIssueRequest;
 import org.example.issuecoupon.service.CouponIssueService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static org.example.issuecoupon.AccessTokenProvider.setAccessToken;
 
 @RestController
 @RequestMapping("/coupon-issues")
@@ -14,9 +17,16 @@ public class CouponIssueController {
 
     private final CouponIssueService couponIssueService;
 
+    public static final String USER_ID_HEADER = "X-User-Id";
+
     @PostMapping
-    public ResponseEntity<Void> issueCoupon(@RequestBody @Valid SaveCouponIssueRequest saveCouponIssueRequest) {
-        couponIssueService.issueCoupon(saveCouponIssueRequest);
+    public ResponseEntity<Void> issueCoupon(
+            @RequestBody @Valid SaveCouponIssueRequest saveCouponIssueRequest,
+            @RequestHeader(USER_ID_HEADER) String userId,
+            HttpServletRequest request
+    ) {
+        setAccessToken(request);
+        couponIssueService.issueCoupon(saveCouponIssueRequest, userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/CouponIssue.java
@@ -21,11 +21,11 @@ public class CouponIssue {
         this.userId = userId;
     }
 
-    public static CouponIssue of(Long couponId, Long userId) {
+    public static CouponIssue of(Long couponId, String userId) {
         return CouponIssue.builder()
                 .couponStatus(ACTIVE)
                 .couponId(couponId)
-                .userId(userId)
+                .userId(Long.parseLong(userId))
                 .build();
     }
 }

--- a/issue-coupon/src/main/java/org/example/issuecoupon/domain/dto/SaveCouponIssueRequest.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/domain/dto/SaveCouponIssueRequest.java
@@ -1,7 +1,6 @@
 package org.example.issuecoupon.domain.dto;
 
 public record SaveCouponIssueRequest(
-        Long userId,
         Long eventId,
         Long couponId
 ) {

--- a/issue-coupon/src/main/java/org/example/issuecoupon/service/CouponIssueService.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/service/CouponIssueService.java
@@ -22,13 +22,12 @@ public class CouponIssueService {
     private final CouponIssueRepository couponIssueRepository;
 
     @Transactional
-    public void issueCoupon(SaveCouponIssueRequest saveCouponIssueRequest) {
+    public void issueCoupon(SaveCouponIssueRequest saveCouponIssueRequest, String userId) {
         Long couponId = saveCouponIssueRequest.couponId();
-        Long userId = saveCouponIssueRequest.userId();
         log.info("Issuing Coupon. Coupon ID: [{}], User ID: [{}]", couponId, userId);
 
         CouponCache cachedCoupon = getCouponFromCache(couponId);
-        validateCouponIssue(cachedCoupon, String.valueOf(userId));
+        validateCouponIssue(cachedCoupon, userId);
 
         saveCouponIssue(couponId, userId);
         log.info("Coupon Issued Successfully. Coupon ID: [{}], User ID: [{}]", couponId, userId);
@@ -67,7 +66,7 @@ public class CouponIssueService {
         }
     }
 
-    private void saveCouponIssue(Long couponId, Long userId) {
+    private void saveCouponIssue(Long couponId, String userId) {
         log.info("Saving Coupon Issue. Coupon ID: [{}], User ID: [{}]", couponId, userId);
         CouponIssue couponIssue = CouponIssue.of(couponId, userId);
         couponIssueRepository.save(couponIssue);

--- a/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueConcurrencyTest.java
+++ b/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueConcurrencyTest.java
@@ -31,8 +31,8 @@ public class CouponIssueConcurrencyTest {
             long userId = i;
             executorService.submit(() -> {
                 try {
-                    SaveCouponIssueRequest saveCouponIssueRequest = new SaveCouponIssueRequest(userId, 1L, 1L);
-                    couponIssueService.issueCoupon(saveCouponIssueRequest);
+                    SaveCouponIssueRequest saveCouponIssueRequest = new SaveCouponIssueRequest(1L, 1L);
+                    couponIssueService.issueCoupon(saveCouponIssueRequest, "1L");
                     successCount.incrementAndGet();
                 } catch (IssueCouponException e) {
                     failCount.incrementAndGet();

--- a/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
+++ b/issue-coupon/src/test/java/org/example/issuecoupon/service/CouponIssueServiceTest.java
@@ -38,7 +38,7 @@ class CouponIssueServiceTest {
     private CouponIssueService couponIssueService;
 
     private SaveCouponIssueRequest createRequest() {
-        return new SaveCouponIssueRequest(userId, eventId, couponId);
+        return new SaveCouponIssueRequest(eventId, couponId);
     }
 
     private CouponCache createCouponCache() {
@@ -73,7 +73,7 @@ class CouponIssueServiceTest {
         when(couponIssueApiService.requestCouponValidation(any(CouponCache.class), anyString())).thenReturn("SUCCESS");
 
         // When
-        couponIssueService.issueCoupon(request);
+        couponIssueService.issueCoupon(request, "1L");
 
         // Then
         verify(couponIssueRepository).save(any(CouponIssue.class));
@@ -91,7 +91,7 @@ class CouponIssueServiceTest {
                 .thenReturn("COUPON_ISSUE_QUANTITY_EXCEEDED");
 
         // When & Then
-        assertThrows(IssueCouponException.class, () -> couponIssueService.issueCoupon(request), COUPON_ISSUE_QUANTITY_EXCEEDED.name());
+        assertThrows(IssueCouponException.class, () -> couponIssueService.issueCoupon(request, "1L"), COUPON_ISSUE_QUANTITY_EXCEEDED.name());
     }
 
     @Test
@@ -106,7 +106,7 @@ class CouponIssueServiceTest {
                 .thenReturn("COUPON_ALREADY_ISSUED_BY_USER");
 
         // When & Then
-        assertThrows(IssueCouponException.class, () -> couponIssueService.issueCoupon(request), COUPON_ALREADY_ISSUED_BY_USER.name());
+        assertThrows(IssueCouponException.class, () -> couponIssueService.issueCoupon(request, "1L"), COUPON_ALREADY_ISSUED_BY_USER.name());
     }
 
     @Test
@@ -121,7 +121,7 @@ class CouponIssueServiceTest {
         when(couponIssueApiService.requestCouponValidation(any(CouponCache.class), anyString())).thenReturn("SUCCESS");
 
         // When
-        couponIssueService.issueCoupon(request);
+        couponIssueService.issueCoupon(request, "1L");
 
         // Then
         verify(couponIssueApiService).requestSaveCouponFromCache(any(CouponCache.class));


### PR DESCRIPTION
**개요**
Gateway 서버에서 JWT 토큰 기반 인증 필터를 쿠폰 발급 경로에 적용하고, 
Issue Coupon 서비스에서 사용자 ID를 Access Token에서 추출하여 처리하는 기능을 추가

**주요 변경사항**
- **JWT 토큰 인증 필터 수정**
   - `TokenAuthenticationFilter`에서 쿠폰 발급 경로(`/coupon-issues`)에만 토큰 인증을 강제 적용하도록 수정.
- **쿠폰 발급 컨트롤러 변경**
   - 쿠폰 발급 요청 시 `X-User-Id` 헤더에서 사용자 ID를 수신하고, Access Token을 설정하는 로직 추가.
- **도메인 및 서비스 수정**
   - `CouponIssue` 도메인과 `CouponIssueService`에서 사용자 ID를 `String`으로 처리하도록 변경.
   - `SaveCouponIssueRequest`에서 사용자 ID 필드를 제거하고, `userId`는 요청 헤더에서 처리하도록 리팩토링.