### PR TITLE
 Kafka Producer Acks 및 Minimum In-Sync Replicas 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@
 ## 🛠️ 분산 아키텍처
 - [Kafka를 활용해 검증 서비스와 발행 서비스 분리](https://github.com/yurim0628/off-coupon/wiki/Kafka%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4-%EA%B2%80%EC%A6%9D-%EC%84%9C%EB%B9%84%EC%8A%A4%EC%99%80-%EB%B0%9C%ED%96%89-%EC%84%9C%EB%B9%84%EC%8A%A4-%EB%B6%84%EB%A6%AC%ED%95%98%EA%B8%B0)
 - [[Kafka] Producer Configurations(1) ‐ Compression & Batch](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(1)-%E2%80%90-%08Compression-&-Batch)
+- [[Kafka] Producer Configurations(2) ‐ Acks & Minimum In‐Sync Replicas](https://github.com/yurim0628/off-coupon/wiki/Kafka-Producer-Configurations%282%29-%E2%80%90-Acks-%26-Minimum-In%E2%80%90Sync-Replicas/_edit)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,22 +11,59 @@ services:
     networks:
       - off-coupon-network
 
-  kafka:
+  kafka-1:
     image: bitnami/kafka:latest
-    container_name: kafka_container
+    container_name: kafka_1
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_container:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper_container:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_1:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+    networks:
+      - off-coupon-network
+
+  kafka-2:
+    image: bitnami/kafka:latest
+    container_name: kafka_2
+    ports:
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper_container:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_2:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+    networks:
+      - off-coupon-network
+
+  kafka-3:
+    image: bitnami/kafka:latest
+    container_name: kafka_3
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper_container:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka_3:9094
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9094
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
     networks:
       - off-coupon-network
 
   kafka-exporter:
     image: danielqsj/kafka-exporter
     container_name: kafka-exporter
-    command: [ "--kafka.server=kafka_container:9092" ]
+    command: [
+      "--kafka.server=kafka_1:9092",
+      "--kafka.server=kafka_2:9093",
+      "--kafka.server=kafka_3:9094"
+    ]
     ports:
       - 9308:9308
     networks:
@@ -198,12 +235,14 @@ services:
     depends_on:
       - mysql
       - zookeeper
-      - kafka
+      - kafka-1
+      - kafka-2
+      - kafka-3
       - config-server-module
       - eureka-server-module
       - gateway-server-module
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka_container:9092
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka_1:9092,kafka_2:9093,kafka_3:9094
       SPRING_REDIS_HOST: redis-master
       SPRING_REDIS_PORT: 6379
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql-container:3306/sparta
@@ -223,12 +262,14 @@ services:
     depends_on:
       - mysql
       - zookeeper
-      - kafka
+      - kafka-1
+      - kafka-2
+      - kafka-3
       - config-server-module
       - eureka-server-module
       - gateway-server-module
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka_container:9092
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka_1:9092,kafka_2:9093,kafka_3:9094
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql-container:3306/sparta
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root1234!!

--- a/issue-coupon/src/main/java/org/example/issuecoupon/config/KafkaProducerConfig.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/config/KafkaProducerConfig.java
@@ -32,18 +32,26 @@ public class KafkaProducerConfig {
     @Value("${spring.kafka.producer.compression-type}")
     private String compressionType;
 
+    @Value("${spring.kafka.producer.acks}")
+    private String acks;
+
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> producerConfig = new HashMap<>();
+
+        // Messaging behavior-related configurations
         producerConfig.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         producerConfig.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         producerConfig.put(VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
 
+        // Batch and compression-related configurations
         producerConfig.put(BATCH_SIZE_CONFIG, batchSize);
         producerConfig.put(LINGER_MS_CONFIG, lingerMs);
         producerConfig.put(BUFFER_MEMORY_CONFIG, bufferMemory);
-
         producerConfig.put(COMPRESSION_TYPE_CONFIG, compressionType);
+
+        // Reliability-related configurations
+        producerConfig.put(ACKS_CONFIG, acks);
 
         return new DefaultKafkaProducerFactory<>(producerConfig);
     }


### PR DESCRIPTION
### 개요
- Kafka 클러스터의 안정성과 데이터 무결성을 보장하기 위해 `acks=all` 설정과 `min.insync.replicas` 값을 적용했습니다. 
- 이를 통해 메시지 손실 방지와 장애 상황에서도 안정적인 서비스 제공을 목표로 구성했습니다.

### 주요 변경사항

1. Kafka Producer 설정 변경
   - `acks=all` 설정을 추가하여 모든 ISR(In-Sync Replicas)로부터 확인을 받을 때 메시지를 성공적으로 전송 완료.
   - Kafka Producer Config에 `acks` 설정 로직 반영.

2. Kafka 브로커 설정 업데이트
   - 브로커 복제본 수를 `replication.factor=3`로 설정하여 높은 가용성 보장.
   - `KAFKA_MIN_INSYNC_REPLICAS=2`로 설정하여 최소 두 개의 ISR이 메시지 복제를 완료하도록 구성.

3. Docker Compose 업데이트
   - Kafka 브로커 3개를 추가하여 클러스터 구성.
   - `docker-compose.yml`에 복제 및 ISR 관련 설정 추가.

4. 장애 테스트 및 검증
   - 리더 브로커 장애 시 다른 브로커로 리더 전환 확인.
   - 장애 발생 후 메시지 손실 없이 애플리케이션의 지속적인 메시지 처리 검증.

### 테스트 결과 요약

1. 리더 브로커 장애 발생
   - `docker stop kafka_1`로 리더 브로커 중단.
   - Kafka 클러스터가 새로운 리더를 정상적으로 선출(kafka_3).

2. 데이터 손실 방지 확인
   - 메시지 전송 시 최소 두 개의 ISR에서 확인을 완료(`min.insync.replicas=2`).
   - 리더 장애 시에도 메시지 손실 없이 지속적으로 처리 완료.

3. 애플리케이션 동작
   - 리더 브로커 장애 후에도 애플리케이션에서 메시지 처리 중단 없이 지속적으로 동작.
   - 장애 복구(kafka_1) 후, 클러스터가 정상적으로 재구성.

자세한 내용은 [[Kafka] Producer Configurations(2) ‐ Acks & Minimum In‐Sync Replicas](https://github.com/yurim0628/off-coupon/wiki/Kafka-Producer-Configurations%282%29-%E2%80%90-Acks-%26-Minimum-In%E2%80%90Sync-Replicas/_edit) 에서 확인할 수 있습니다.

