### PR TITLE
Kafka Producer Reliability Configuration(2) - Idempotence 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@
 - [Kafka를 활용해 검증 서비스와 발행 서비스 분리](https://github.com/yurim0628/off-coupon/wiki/Kafka%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4-%EA%B2%80%EC%A6%9D-%EC%84%9C%EB%B9%84%EC%8A%A4%EC%99%80-%EB%B0%9C%ED%96%89-%EC%84%9C%EB%B9%84%EC%8A%A4-%EB%B6%84%EB%A6%AC%ED%95%98%EA%B8%B0)
 - [[Kafka] Producer Configurations(1) ‐ Compression & Batch](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(1)-%E2%80%90-%08Compression-&-Batch)
 - [[Kafka] Producer Configurations(2) ‐ Acks & Minimum In‐Sync Replicas](https://github.com/yurim0628/off-coupon/wiki/Kafka-Producer-Configurations%282%29-%E2%80%90-Acks-%26-Minimum-In%E2%80%90Sync-Replicas/_edit)
+- [[Kafka] Producer Configurations(3) - Idempotence](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(3)-%E2%80%90-Idempotence)

--- a/issue-coupon/src/main/java/org/example/issuecoupon/config/KafkaProducerConfig.java
+++ b/issue-coupon/src/main/java/org/example/issuecoupon/config/KafkaProducerConfig.java
@@ -35,6 +35,15 @@ public class KafkaProducerConfig {
     @Value("${spring.kafka.producer.acks}")
     private String acks;
 
+    @Value("${spring.kafka.producer.properties.enable.idempotence}")
+    private boolean enableIdempotence;
+
+    @Value("${spring.kafka.producer.retries}")
+    private int retries;
+
+    @Value("${spring.kafka.producer.properties.max.in.flight.requests.per.connection}")
+    private int maxInflightRequests;
+
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> producerConfig = new HashMap<>();
@@ -52,6 +61,9 @@ public class KafkaProducerConfig {
 
         // Reliability-related configurations
         producerConfig.put(ACKS_CONFIG, acks);
+        producerConfig.put(RETRIES_CONFIG, retries);
+        producerConfig.put(ENABLE_IDEMPOTENCE_CONFIG, enableIdempotence);
+        producerConfig.put(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, maxInflightRequests);
 
         return new DefaultKafkaProducerFactory<>(producerConfig);
     }


### PR DESCRIPTION
### 개요
- Kafka Producer에 멱등성 설정(`enable.idempotence`)을 추가하여 메시지 중복 전송을 방지하고 메시지 전송의 안정성 강화. 
- 이를 통해 장애 발생 시에도 메시지가 중복 없이 정확히 처리되도록 최적화.


### 주요 변경사항
1. **Kafka Producer 멱등성 설정 추가**
   - `enable.idempotence=true` 설정으로 메시지 중복 전송 방지.
   - `retries`와 `max.in.flight.requests.per.connection` 설정을 조정하여 멱등성 보장.
  
2. **Kafka Producer Config 업데이트**
   - `acks=all` 설정과 함께 멱등성 설정을 통합하여 높은 데이터 무결성 확보.
   - Producer 설정에서 `retries` 값을 조정하여 장애 발생 시 재시도 횟수 증가.

3. **문서화**
   - README 및 Wiki에 멱등성 설정과 적용 방법에 대한 설명 추가.