### PR TITLE
Kafka Consumer Configuration(1) - Manual Offset Commit 및 ACK Mode 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@
 - [[Kafka] Producer Configurations(1) ‐ Compression & Batch](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(1)-%E2%80%90-%08Compression-&-Batch)
 - [[Kafka] Producer Configurations(2) ‐ Acks & Minimum In‐Sync Replicas](https://github.com/yurim0628/off-coupon/wiki/%5Bkafka%5D-Kafka-Producer-Configurations(2)-%E2%80%90-Acks-&-Minimum-In%E2%80%90Sync-Replicas)
 - [[Kafka] Producer Configurations(3) - Idempotence](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(3)-%E2%80%90-Idempotence)
-
+- [[Kafka] Consumer Configurations(1) - Offset Commit Strategy](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Consumer-Configurations(1)-%E2%80%90-Offset-Commit-Strategy)

--- a/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+import static org.springframework.kafka.listener.ContainerProperties.AckMode.MANUAL_IMMEDIATE;
 import static org.springframework.kafka.support.serializer.ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS;
 import static org.springframework.kafka.support.serializer.ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS;
 import static org.springframework.kafka.support.serializer.JsonDeserializer.TRUSTED_PACKAGES;
@@ -32,6 +33,12 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.trusted-packages}")
     private String trustedPackages;
 
+    @Value("${spring.kafka.consumer.enable-auto-commit}")
+    private boolean enableAutoCommit;
+
+    @Value("${spring.kafka.consumer.auto-offset-reset}")
+    private String autoOffsetReset;
+
     @Bean
     public DefaultKafkaConsumerFactory<String, CouponIssue> consumerFactory() {
         Map<String, Object> consumerConfig = new HashMap<>();
@@ -45,6 +52,9 @@ public class KafkaConsumerConfig {
 
         consumerConfig.put(TRUSTED_PACKAGES, trustedPackages);
 
+        consumerConfig.put(ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+        consumerConfig.put(AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+
         return new DefaultKafkaConsumerFactory<>(
                 consumerConfig,
                 new StringDeserializer(),
@@ -55,6 +65,7 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, CouponIssue> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, CouponIssue> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.getContainerProperties().setAckMode(MANUAL_IMMEDIATE);
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.couponkafka.domain.CouponIssue;
 import org.example.couponkafka.service.port.CouponIssueRepository;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,9 +13,13 @@ public class CouponIssueConsumer {
 
     private final CouponIssueRepository couponIssueRepository;
 
-    @KafkaListener(topics = "TimeAttackCouponIssue", groupId = "Coupon-TimeAttackCouponIssue")
-    public void listener(CouponIssue couponIssue) {
+    @KafkaListener(
+            topics = "TimeAttackCouponIssue",
+            groupId = "Coupon-TimeAttackCouponIssue"
+    )
+    public void listener(CouponIssue couponIssue, Acknowledgment acknowledgment) {
         saveCouponIssue(couponIssue);
+        acknowledgment.acknowledge();
     }
 
     private void saveCouponIssue(CouponIssue couponIssue) {


### PR DESCRIPTION
### **개요**
- Kafka Consumer에서 메시지 처리 후 수동으로 오프셋을 커밋하도록 설정을 변경하고, ACK 모드(`MANUAL_IMMEDIATE`)를 추가하여 메시지 처리의 신뢰성과 안정성 강화. 
- 이를 통해 메시지 중복 처리와 데이터 손실을 방지할 수 있도록 최적화.

### **주요 변경사항**

1. **Kafka Consumer 설정 업데이트**
   - `enable.auto.commit=false`로 자동 커밋 비활성화.
   - ACK 모드를 `MANUAL_IMMEDIATE`로 설정하여 메시지 처리 후 즉시 커밋 수행.

2. **수동 오프셋 커밋 구현**
   - `Acknowledgment.acknowledge()` 메서드로 메시지 처리 후 오프셋을 직접 커밋.
   - Consumer가 비정상 종료되더라도 중복 처리 가능성을 줄임.

3. **KafkaConsumerConfig 추가 설정**
   - `auto-offset-reset=earliest`로 설정하여 초기 컨슈머 그룹 실행 시 처음 오프셋부터 처리.
   - Consumer Factory 및 Listener Container Factory 구성에 ACK 모드 설정.

4. **문서화**
   - README 및 Wiki에 수동 오프셋 커밋 및 ACK 모드 적용 방법과 설정값 설명 추가.
