### PR TITLE
feat: Kafka 컨슈머 안정성 강화 및 쿠폰 중복 발급 방지

### DIFF
--- a/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
@@ -50,6 +50,12 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.auto-offset-reset}")
     private String autoOffsetReset;
 
+    @Value("${spring.kafka.consumer.max-poll-records}")
+    private int maxPollRecords;
+
+    @Value("${spring.kafka.consumer.max-poll-interval}")
+    private int maxPollInterval;
+
     @Bean
     public DefaultKafkaConsumerFactory<String, CouponIssue> consumerFactory() {
         Map<String, Object> consumerConfig = new HashMap<>();
@@ -66,6 +72,9 @@ public class KafkaConsumerConfig {
 
         consumerConfig.put(ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
         consumerConfig.put(AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+
+        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval);
 
         return new DefaultKafkaConsumerFactory<>(
                 consumerConfig,

--- a/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/CouponIssueRepositoryImpl.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/CouponIssueRepositoryImpl.java
@@ -13,7 +13,7 @@ public class CouponIssueRepositoryImpl implements CouponIssueRepository {
     private final CouponIssueJpaRepository couponIssueJpaRepository;
 
     @Override
-    public CouponIssue save(CouponIssue couponIssue) {
-        return couponIssueJpaRepository.save(CouponIssueEntity.fromModel(couponIssue)).toModel();
+    public void save(CouponIssue couponIssue) {
+        couponIssueJpaRepository.save(CouponIssueEntity.fromModel(couponIssue)).toModel();
     }
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/entity/CouponIssueEntity.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/entity/CouponIssueEntity.java
@@ -50,6 +50,7 @@ public class CouponIssueEntity {
                 .id(id)
                 .couponStatus(status)
                 .couponId(couponId)
+                .userId(userId)
                 .build();
     }
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/entity/CouponIssueEntity.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/infrastructure/entity/CouponIssueEntity.java
@@ -12,7 +12,18 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Entity
-@Table(name = "coupon_issues")
+@Table(
+        name = "coupon_issues",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "unique_user_coupon",
+                        columnNames = {
+                                "userId",
+                                "couponId"
+                        }
+                )
+        }
+)
 @NoArgsConstructor(access = PROTECTED)
 public class CouponIssueEntity {
 

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.couponkafka.domain.CouponIssue;
 import org.example.couponkafka.service.port.CouponIssueRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.couponkafka.util.TransactionUtils.registerAfterCommit;
 
 @Slf4j
 @Service
@@ -23,8 +26,13 @@ public class CouponIssueConsumer {
     @Transactional
     public void listener(CouponIssue couponIssue, Acknowledgment acknowledgment) {
         try {
-            log.info("Received CouponIssue for User ID: [{}]", couponIssue.getUserId());
+            log.info("Received CouponIssue: User ID: [{}], Coupon ID: [{}]",
+                    couponIssue.getUserId(), couponIssue.getCouponId());
             saveCouponIssue(couponIssue);
+            registerAfterCommit(acknowledgment::acknowledge);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate CouponIssue detected for User ID: [{}], Coupon ID: [{}]",
+                    couponIssue.getUserId(), couponIssue.getCouponId());
             acknowledgment.acknowledge();
         } catch (Exception e) {
             throw new RuntimeException("Failed to Save CouponIssue. User ID: " + couponIssue.getUserId(), e);

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
@@ -7,6 +7,7 @@ import org.example.couponkafka.service.port.CouponIssueRepository;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -19,8 +20,10 @@ public class CouponIssueConsumer {
             topics = "TimeAttackCouponIssue",
             groupId = "Coupon-TimeAttackCouponIssue"
     )
+    @Transactional
     public void listener(CouponIssue couponIssue, Acknowledgment acknowledgment) {
         try {
+            log.info("Received CouponIssue for User ID: [{}]", couponIssue.getUserId());
             saveCouponIssue(couponIssue);
             acknowledgment.acknowledge();
         } catch (Exception e) {

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/port/CouponIssueRepository.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/port/CouponIssueRepository.java
@@ -4,5 +4,5 @@ import org.example.couponkafka.domain.CouponIssue;
 
 public interface CouponIssueRepository {
 
-    CouponIssue save(CouponIssue couponIssue);
+    void save(CouponIssue couponIssue);
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/util/TransactionUtils.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/util/TransactionUtils.java
@@ -1,0 +1,22 @@
+package org.example.couponkafka.util;
+
+import lombok.NoArgsConstructor;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class TransactionUtils {
+
+    public static void registerAfterCommit(Runnable action) {
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        action.run();
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
## ✨ 개요

쿠폰 발급 이벤트 처리 로직에서 메시지 손실/중복 문제를 방지

## 🔑 주요 변경 사항
* **Kafka Consumer 안정성 강화**
  * `manual_immediate` 방식의 즉시 오프셋 커밋 → 트랜잭션 커밋 이후 오프셋 커밋으로 변경
  * `max-poll-records`, `max-poll-interval` 설정 추가
* **쿠폰 발급 중복 방지**
  * `coupon_issues` 테이블에 `(userId, couponId)` 유니크 제약조건 추가
  * 중복 발생 시 `DataIntegrityViolationException` 캐치 후 경고 로그 출력 및 오프셋 커밋

## ✅ 테스트 체크리스트
* [x] 쿠폰 발급 성공 시 → 트랜잭션 커밋 후 오프셋 커밋 확인
* [x] 중복 발급 요청 시 → 예외 대신 경고 로그 출력 및 오프셋 커밋 확인

## 📊 기대 효과
* 메시지 손실 방지: 트랜잭션 이후에만 오프셋 커밋
* 쿠폰 중복 발급 방지: DB 유니크 제약조건 + 예외 처리
